### PR TITLE
SSR-tryouts

### DIFF
--- a/example/server.ts
+++ b/example/server.ts
@@ -1,0 +1,40 @@
+import { Application } from "https://deno.land/x/oak/mod.ts";
+import { html } from "../src/ssr.ts";
+
+// html export is commented out to make ssr.ts serve html
+
+// import globalImportCSS from '../globalImportCSS'
+console.log("entered server.ts");
+const app = new Application();
+
+// app.use((ctx) => {
+//   ctx.response.body = "Hello World!";
+// });
+
+app.use(async (ctx, next) => {
+  const filePath = ctx.request.url.pathname;
+  if (filePath === "/") {
+    console.log("responding to GET request now");
+    ctx.response.type = "text/html";
+    ctx.response.body = html;
+  } else await next();
+  // if (filePath === "/mikeysbundle") {
+  //   ctx.response.type = "application/javascript";
+  //   ctx.response.body = js;
+  // }
+  // if (filePath === "/style?") {
+  //   ctx.response.type = "text/css";
+  //   ctx.response.type = "globalImportCSS";
+  // } else await next();
+});
+
+// Error handler
+app.use(async (ctx) => {
+  ctx.throw(500, "unknown route, please look harder...");
+});
+
+app.addEventListener("listen", () => {
+  console.log(`Listening on localhost: 8000`);
+});
+
+await app.listen({ port: 8000 });

--- a/src/bonusCSS.css
+++ b/src/bonusCSS.css
@@ -1,0 +1,3 @@
+body {
+	background-color: pink;
+}

--- a/src/cssMaker.ts
+++ b/src/cssMaker.ts
@@ -1,0 +1,28 @@
+/**
+ * 
+ * i built this to try to link a css page to the html being served via ssr
+ * i think it's maybe not so useful, but the logic is sound i just can't
+ * get the import right, and i think it's likely becuase of deno...
+ * 
+ */
+
+import vno from "./vno-parser.ts";
+import { ensureFile } from "https://deno.land/std@0.80.0/fs/mod.ts";
+
+const root = {
+  name: "App",
+  path: vno.locate("./App.vue"),
+};
+
+const help = await vno.parse(root);
+const appObj: any = help.filter((obj: any) => obj.name === "App")[0];
+
+const style = appObj.style;
+
+await ensureFile("./bonusCSS.css");
+await Deno.writeTextFile("./bonusCSS.css", style);
+
+//it seems as if Deno can't import CSS files directly yet -- so i'm not
+//sure how that impacts our thoughts on doing a global CSS file ?
+//that doesn't track with what i remember seeing -- but from what i've
+//read on the internet tonight, CSS support is forthcoming...?

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -1,0 +1,45 @@
+import vno from "./vno-parser.ts";
+// import Output from "../vno-build/Output.js";
+
+const root = {
+  name: "App",
+  path: vno.locate("./App.vue"),
+};
+console.log("entered ssr.ts");
+
+const help = await vno.parse(root);
+const appObj: any = help.filter((obj: any) => obj.name === "App")[0];
+
+const template = appObj.template;
+const script = appObj.script;
+const style: string = appObj.style;
+
+const html: string =
+  `<html><head><script type="module" src="{mikeysbundle}"></script><style type="module" src="{csss}"></style></head><body><div>${template}</div></body></html>`;
+
+const js = script;
+console.log("exited ssr.ts");
+// export { html, js };
+
+import { Application } from "https://deno.land/x/oak/mod.ts";
+
+const app = new Application();
+
+app.use(async (ctx, next) => {
+  const filePath = ctx.request.url.pathname;
+  if (filePath === "/") {
+    ctx.response.type = "text/html";
+    ctx.response.body = html;
+  } else await next();
+});
+
+// Error handler
+app.use(async (ctx) => {
+  ctx.throw(500, "unknown route, please look harder...");
+});
+
+app.addEventListener("listen", () => {
+  console.log(`Listening on localhost: 8000`);
+});
+
+await app.listen({ port: 8000 });

--- a/src/vno-parser.ts
+++ b/src/vno-parser.ts
@@ -132,15 +132,21 @@ const vno = {
 
     while (queue.length) {
       const current: any = queue.shift();
-      const data = await Deno.readTextFile(current.path);
+      console.log("queens we are inside the while loop");
+      try {
+        const data = await Deno.readTextFile(current.path);
 
-      await this.template(data, current);
-      await this.script(data, current);
-      await this.style(data, current);
-      await this.imports(data);
+        this.template(data, current);
+        this.script(data, current);
+        this.style(data, current);
+        this.imports(data);
+      } catch (err) {
+        console.log("you fucked up", err);
+      }
 
       cache.push(current);
     }
+    return cache;
   },
 };
 
@@ -149,5 +155,7 @@ const root = {
   path: vno.locate("./App.vue"),
 };
 
-await vno.parse(root);
-console.log("RE$ULTZ --> ", cache);
+// await vno.parse(root);
+// console.log("RE$ULTZ --> ", cache);
+
+export default vno;


### PR DESCRIPTION
- SSR seems functional when serving directly from ssr.ts -- when trying to access vno.parse from remote location (server.ts) error is thrown in async file read.

- added try/catch for errors inside the vno.parse in attempt to debug and removed await statements inside the while loop as they weren't being utilized 

- pulled and created separate CSS file in attempt to serve that with HTML but ran into trouble importing it with deno -- this may not be necessary, but the logic works for creating CSS files from the style tags -- could be repurposed to create js/html files if we wanted (possibly)

