### PR TITLE
proposal: use dynamic imports for run server

### DIFF
--- a/example/server.ts
+++ b/example/server.ts
@@ -1,31 +1,31 @@
 import { Application, join, log, send } from "./deps.ts";
 
-const port: number = 3000;
-const server: Application = new Application();
+export default async function serve() {
+  const port: number = 3000;
+  const server: Application = new Application();
 
-server.use(async (ctx, next) => {
-  const filePath = ctx.request.url.pathname;
-  if (filePath === "/") {
-    await send(ctx, ctx.request.url.pathname, {
-      root: join(Deno.cwd(), "public"),
-      index: "index.html",
-    });
-  } else if (filePath === "/build.js") {
-    ctx.response.type = "application/javascript";
-    await send(ctx, filePath, {
-      root: join(Deno.cwd(), "vno-build"),
-      index: "build.js",
-    });
-  } else if (filePath === "/style.css") {
-    ctx.response.type = "text/css";
-    await send(ctx, filePath, {
-      root: join(Deno.cwd(), "vno-build"),
-      index: "style.css",
-    });
-  } else await next();
-});
+  server.use(async (ctx, next) => {
+    const filePath = ctx.request.url.pathname;
+    if (filePath === "/") {
+      await send(ctx, ctx.request.url.pathname, {
+        root: join(Deno.cwd(), "public"),
+        index: "index.html",
+      });
+    } else if (filePath === "/build.js") {
+      ctx.response.type = "application/javascript";
+      await send(ctx, filePath, {
+        root: join(Deno.cwd(), "vno-build"),
+        index: "build.js",
+      });
+    } else if (filePath === "/style.css") {
+      ctx.response.type = "text/css";
+      await send(ctx, filePath, {
+        root: join(Deno.cwd(), "vno-build"),
+        index: "style.css",
+      });
+    } else await next();
+  });
 
-if (import.meta.main) {
   log.info("Server is up and running on http://localhost:" + port);
   await server.listen({ port });
 }


### PR DESCRIPTION
This change removes the need to `--allow-run` by using dynamic imports instead of a subcommand. Dynamic imports contain their fair share of security concerns, just like `Deno.run` but allow running code within the same sandbox, and therefore the same permission level.