### PR TITLE
feat: remove commented code from the compilation

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,8 @@ export interface UtilityInterface {
     replaced?: string,
   ): string[];
   preorderScrub: Function;
+  multilineCommentPattern: string | RegExp;
+  htmlCommentPattern: string | RegExp;
 }
 // #endregion
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,6 +93,8 @@ const utils: UtilityInterface = {
   ) {
     return str.slice(start, end).replace(regex, replaced).split(split);
   },
+  multilineCommentPattern: /\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\//gm,
+  htmlCommentPattern: /<!--([\s\S]*?)-->/gm
 };
 
 export default utils;

--- a/src/strategies/parser-utils/parseScript.ts
+++ b/src/strategies/parser-utils/parseScript.ts
@@ -40,9 +40,14 @@ export default function parseScript(current: ComponentInterface) {
       const exportStart = Utils.indexOfRegExp(/^(export)/, script);
       const exportEnd = script.lastIndexOf("}");
 
-      // returns a stringifed and trimmed version of our components script
+      // returns a stringified and trimmed version of our components script
       current.script = Utils.sliceAndTrim(script, exportStart + 1, exportEnd);
 
+      // remove comments /* */ in script and style tag's
+      if (current.path.toString().includes(".vue")) {
+        current.split = current.split.join("\n").replace(Utils.multilineCommentPattern, "").split("\n");
+        current.script = current.script.replace(Utils.multilineCommentPattern, "");
+      }
       // Utils.sliceAndTrim(script, exportStart + 1, exportEnd);
 
       // locate if this component has any children

--- a/src/strategies/parser-utils/parseStyle.ts
+++ b/src/strategies/parser-utils/parseStyle.ts
@@ -15,6 +15,7 @@ export default function parseStyle(current: ComponentInterface) {
       }
       // stringify, trim, and save style to component object
       current.style = Utils.sliceAndTrim(current.split, open + 1, close);
+      current.style = current.style.replace(Utils.multilineCommentPattern, "");
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser-utils/parseTemplate.ts
+++ b/src/strategies/parser-utils/parseTemplate.ts
@@ -15,8 +15,9 @@ export default function parseTemplate(current: ComponentInterface) {
           `There was an error isolating content inside of <template> tags for ${current.label}.vue`
         );
       }
-      // stringify, trim, and save on template property
-      current.template = Utils.sliceAndTrim(split, open + 1, close);
+      // stringify, trim, remove comments, and save on template property
+      current.template = Utils.sliceAndTrim(split, open + 1, close)
+                              .replace(Utils.htmlCommentPattern, "");
       // slice the split property to minimize the length of data
       current.split = split.slice(close + 1);
     }


### PR DESCRIPTION
this resolves part of #53 removes multiple line css and js comments from compilation 
```js
/* */ 
```
also removes commented code in html
```html
 <!--  -->
```

## from this

```vue
<template>
  <div id="app">
    <!-- <img
      src="https://svgshare.com/i/SNz.svg"
      alt="image"
      border="0"
      width="450"
      height="450"
    /> -->
    <HelloVno msg="you are building: your project with vno" />
  </div>
</template>

<script>
import HelloVno from './components/HelloVno.vue';

export default {
  name: 'app',
 components: { /* HelloVno */ }
}
</script>

<style>
html {
  background-color: #203A42;
}
/*
#app {
  font-family: Avenir, Helvetica, Arial, sans-serif;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  text-align: center;
  color: #79d0b2;
  margin-top: 60px;
}*/
</style>
```
## to this 

`build.js`

```js
// deno-lint-ignore-file
import Vue from "https://cdn.jsdelivr.net/npm/vue@2.6.12/dist/vue.esm.browser.js";

const App = new Vue(
  {
    template:
      ` <div id="app">  <HelloVno msg="you are building: your project with vno" /> </div>`,
    name: "app",
    components: {},
  },
);

App.$mount("#app");
export default App;
```

`style.css`

```css
html {
  background-color: #203a42;
}
```

