### PR TITLE
Support to typescript and scss

### DIFF
--- a/example/typescript_scss/App.vue
+++ b/example/typescript_scss/App.vue
@@ -1,0 +1,45 @@
+<template>
+  <div id="app">
+    <img
+      src="https://svgshare.com/i/SNz.svg"
+      alt="image"
+      border="0"
+      width="450"
+      height="450"
+    />
+    <Home :msg="message" />
+  </div>
+</template>
+
+<script lang="ts">
+import Home from "./components/Home.vue";
+
+export default {
+  name: "app",
+  components: { Home },
+  data(): { message: string } {
+    const message: string = "you are building: Vue App with vno";
+
+    return {
+      message,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+$bg-color: #203a42;
+$text-color: #79d0b2;
+
+html {
+  background-color: $bg-color;
+}
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: $text-color;
+  margin-top: 60px;
+}
+</style>

--- a/example/typescript_scss/README.md
+++ b/example/typescript_scss/README.md
@@ -1,0 +1,16 @@
+<img src="../../assets/vnologo.svg"
+     alt="vno logo"
+     style="float: left; margin-right: 10px;" />
+
+<p align='right'> - Logo Design by <a href='https://www.behance.net/bmccabe'>Brendan McCabe</a></p>
+
+# Example using typescript and scss
+
+use:
+
+`run`
+
+```sh
+vno run dev
+```
+then go to [localhost](http://localhost:3000/)

--- a/example/typescript_scss/components/Home.vue
+++ b/example/typescript_scss/components/Home.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="hello">
+    <h1 @click="Alert">{{ msg }}</h1>
+    <p>
+      <br />
+    </p>
+    <h3>
+      <a href="https://vno.land" target="_blank" rel="noopener">vno.land</a> &
+      <a
+        href="https://github.com/oslabs-beta/vno"
+        target="_blank"
+        rel="noopener"
+      >
+        github
+      </a>
+    </h3>
+    <ul>
+      <br />
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  name: "home",
+  props: {
+    msg: String,
+  },
+  methods: {
+    Alert(): void {
+      alert("Hi!!!");
+    },
+  },
+};
+</script>
+
+<style>
+h3 {
+  margin: 40px 0 0;
+}
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+li {
+  display: inline-block;
+  margin: 0 10px;
+}
+a {
+  color: #79d0b2;
+}
+</style>

--- a/example/typescript_scss/public/index.html
+++ b/example/typescript_scss/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
+    <link rel="stylesheet" href="./style.css" />
+    <title>typescript_scss</title>
+  </head>
+  <body>
+    <div id="app">
+      <!-- built files will be auto injected -->
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
+    <script type="module" src="./build.js"></script>
+  </body>
+</html>

--- a/example/typescript_scss/vno-build/build.js
+++ b/example/typescript_scss/vno-build/build.js
@@ -1,0 +1,8 @@
+// deno-lint-ignore-file
+import Vue from 'https://cdn.jsdelivr.net/npm/vue@2.6.12/dist/vue.esm.browser.js';
+
+const Home = Vue.component("home", {template: ` <div class="hello"> <h1 @click="Alert">{{ msg }}</h1> <p> <br /> </p> <h3> <a href="https://vno.land" target="_blank" rel="noopener">vno.land</a> & <a href="https://github.com/oslabs-beta/vno" target="_blank" rel="noopener"> github </a> </h3> <ul> <br /> </ul> </div>`,name: 'home', props: { msg: String, }, methods: { Alert() { alert("Hi!!!"); } } });
+const App = new Vue({template: ` <div id="app"> <img src="https://svgshare.com/i/SNz.svg" alt="image" border="0" width="450" height="450" /> <Home :msg="message" /> </div>`,name: "app", components: { Home }, data() { const message = "you are building: Vue App with vno"; return { message, }; }, });
+
+App.$mount("#app");
+export default App;

--- a/example/typescript_scss/vno-build/style.css
+++ b/example/typescript_scss/vno-build/style.css
@@ -1,0 +1,12 @@
+h3 { margin: 40px 0 0;}ul { list-style-type: none; padding: 0;}li { display: inline-block; margin: 0 10px;} a { color: #79d0b2;}html {
+  background-color: #203a42;
+}
+
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #79d0b2;
+  margin-top: 60px;
+}

--- a/example/typescript_scss/vno.config.json
+++ b/example/typescript_scss/vno.config.json
@@ -1,0 +1,9 @@
+{
+  "root": "App",
+  "entry": "./",
+  "options": {
+    "child": "Home",
+    "port": "3000",
+    "title": "typescript_scss"
+  }
+}

--- a/src/lib/deps.ts
+++ b/src/lib/deps.ts
@@ -8,9 +8,21 @@ import * as asrt from "https://deno.land/std@0.83.0/testing/asserts.ts";
 // third-party
 import _ from "https://cdn.skypack.dev/lodash"; // lodash
 import ProgressBar from "https://deno.land/x/progress@v1.2.3/mod.ts";
+import { compile as scssCompiler } from "https://raw.githubusercontent.com/crewdevio/deno_sass2/master/mod.ts";
 
 // oak
 import * as oak from "https://deno.land/x/oak@v6.3.1/mod.ts";
 import { superoak } from "https://deno.land/x/superoak@3.0.0/mod.ts";
 
-export { _, colors, fs, http, oak, path, ProgressBar, superoak, asrt };
+export {
+  _,
+  asrt,
+  colors,
+  fs,
+  http,
+  oak,
+  path,
+  ProgressBar,
+  scssCompiler,
+  superoak,
+};

--- a/src/strategies/initialize.ts
+++ b/src/strategies/initialize.ts
@@ -31,7 +31,7 @@ Initialize.prototype.config = async function (options: OptionsInterface) {
     // the applications cdn is then saved on the root component object
     Storage.root.vue = options.vue || _def.CDN;
     // instantiate the Parser object and invoke the parse method
-    return new (Parser as any)().parse();
+    return await new (Parser as any)().parse();
   } catch (error) {
     return console.error(
       "Error inside of Initialize.config",

--- a/src/strategies/parser-utils/parseStyle.ts
+++ b/src/strategies/parser-utils/parseStyle.ts
@@ -1,9 +1,11 @@
 import { ComponentInterface } from "../../lib/types.ts";
+import { scssCompiler } from "../../lib/deps.ts";
 import Utils from "../../lib/utils.ts";
 
 // parseStyle is responsible for parsing data inside of <style> tags
 export default function parseStyle(current: ComponentInterface) {
   try {
+    let useScss = false;
     if (current.split) {
       // isolate the content inside <style>
       const open = Utils.indexOfRegExp(/<style.*>/gi, current.split);
@@ -11,11 +13,26 @@ export default function parseStyle(current: ComponentInterface) {
       // return if the component has no added styling
       if (open < 0 || close < 0) {
         current.style = undefined;
-        return "parseStyle()=> succesful (no component styling)";
+        return "parseStyle()=> successful (no component styling)";
       }
       // stringify, trim, and save style to component object
       current.style = Utils.sliceAndTrim(current.split, open + 1, close);
       current.style = current.style.replace(Utils.multilineCommentPattern, "");
+
+      // detect scss style lang
+      for (const chunk of current.split) {
+        if (chunk.includes('lang="scss"')) {
+          useScss = true;
+        }
+      }
+
+      // stringify, trim, and save style to component object
+      current.style = Utils.sliceAndTrim(current.split, open + 1, close);
+
+      // compile scss to css
+      if (useScss) {
+        current.style = scssCompiler(current.style as string);
+      }
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser.ts
+++ b/src/strategies/parser.ts
@@ -14,14 +14,14 @@ function Parser(this: ParserInterface) {
 
 // parse is responsible for invoking all the parser-utils
 // functions for each component in the Queue.
-Parser.prototype.parse = function () {
+Parser.prototype.parse = async function () {
   // iterate through the Queue while it is populated
   while (Queue.length) {
     const current = Queue.shift();
 
     if (current) {
       fn.parseTemplate(current);
-      fn.parseScript(current);
+      await fn.parseScript(current);
       fn.parseStyle(current);
       fn.componentStringify(current);
       current.isParsed = true;


### PR DESCRIPTION
closes #57 

adds basic but useful support for typescript and scss

to compile typescript use `Deno.compile`, can be used like this:

```html
<script lang="ts">
import Home from "./components/Home.vue";

export default {
  name: "app",
  components: { Home },
  data(): { message: string } {
    const message: string = "you are building: Vue App with vno";

    return {
      message,
    };
  },
};
</script>
```

and scss is compiled using [deno_sass](https://github.com/littledivy/deno_sass2), can be used like this:

```html
<style lang="scss">
$bg-color: #203a42;
$text-color: #79d0b2;

html {
  background-color: $bg-color;
}
#app {
  font-family: Avenir, Helvetica, Arial, sans-serif;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  text-align: center;
  color: $text-color;
  margin-top: 60px;
}
</style>
```

The url used to import deno sass is a fork that I create to have more control in case of any bug with this