### PR TITLE
Vue3 compiler

### DIFF
--- a/example/typescript_scss/App.vue
+++ b/example/typescript_scss/App.vue
@@ -1,0 +1,45 @@
+<template>
+  <div id="app">
+    <img
+      src="https://svgshare.com/i/SNz.svg"
+      alt="image"
+      border="0"
+      width="450"
+      height="450"
+    />
+    <Home :msg="message" />
+  </div>
+</template>
+
+<script lang="ts">
+import Home from "./components/Home.vue";
+
+export default {
+  name: "app",
+  components: { Home },
+  data(): { message: string } {
+    const message: string = "you are building: Vue App with vno";
+
+    return {
+      message,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+$bg-color: #203a42;
+$text-color: #79d0b2;
+
+html {
+  background-color: $bg-color;
+}
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: $text-color;
+  margin-top: 60px;
+}
+</style>

--- a/example/typescript_scss/README.md
+++ b/example/typescript_scss/README.md
@@ -1,0 +1,16 @@
+<img src="../../assets/vnologo.svg"
+     alt="vno logo"
+     style="float: left; margin-right: 10px;" />
+
+<p align='right'> - Logo Design by <a href='https://www.behance.net/bmccabe'>Brendan McCabe</a></p>
+
+# Example using typescript and scss
+
+use:
+
+`run`
+
+```sh
+vno run dev
+```
+then go to [localhost](http://localhost:3000/)

--- a/example/typescript_scss/components/Home.vue
+++ b/example/typescript_scss/components/Home.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="hello">
+    <h1 @click="Alert">{{ msg }}</h1>
+    <p>
+      <br />
+    </p>
+    <h3>
+      <a href="https://vno.land" target="_blank" rel="noopener">vno.land</a> &
+      <a
+        href="https://github.com/oslabs-beta/vno"
+        target="_blank"
+        rel="noopener"
+      >
+        github
+      </a>
+    </h3>
+    <ul>
+      <br />
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  name: "home",
+  props: {
+    msg: String,
+  },
+  methods: {
+    Alert(): void {
+      alert("Hi!!!");
+    },
+  },
+};
+</script>
+
+<style>
+h3 {
+  margin: 40px 0 0;
+}
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+li {
+  display: inline-block;
+  margin: 0 10px;
+}
+a {
+  color: #79d0b2;
+}
+</style>

--- a/example/typescript_scss/public/index.html
+++ b/example/typescript_scss/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
+    <link rel="stylesheet" href="./style.css" />
+    <title>typescript_scss</title>
+  </head>
+  <body>
+    <div id="app">
+      <!-- built files will be auto injected -->
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
+    <script type="module" src="./build.js"></script>
+  </body>
+</html>

--- a/example/typescript_scss/vno-build/build.js
+++ b/example/typescript_scss/vno-build/build.js
@@ -1,0 +1,8 @@
+// deno-lint-ignore-file
+import Vue from 'https://cdn.jsdelivr.net/npm/vue@2.6.12/dist/vue.esm.browser.js';
+
+const Home = Vue.component("home", {template: ` <div class="hello"> <h1 @click="Alert">{{ msg }}</h1> <p> <br /> </p> <h3> <a href="https://vno.land" target="_blank" rel="noopener">vno.land</a> & <a href="https://github.com/oslabs-beta/vno" target="_blank" rel="noopener"> github </a> </h3> <ul> <br /> </ul> </div>`,name: 'home', props: { msg: String, }, methods: { Alert() { alert("Hi!!!"); } } });
+const App = new Vue({template: ` <div id="app"> <img src="https://svgshare.com/i/SNz.svg" alt="image" border="0" width="450" height="450" /> <Home :msg="message" /> </div>`,name: "app", components: { Home }, data() { const message = "you are building: Vue App with vno"; return { message, }; }, });
+
+App.$mount("#app");
+export default App;

--- a/example/typescript_scss/vno-build/style.css
+++ b/example/typescript_scss/vno-build/style.css
@@ -1,0 +1,12 @@
+h3 { margin: 40px 0 0;}ul { list-style-type: none; padding: 0;}li { display: inline-block; margin: 0 10px;} a { color: #79d0b2;}html {
+  background-color: #203a42;
+}
+
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #79d0b2;
+  margin-top: 60px;
+}

--- a/example/typescript_scss/vno.config.json
+++ b/example/typescript_scss/vno.config.json
@@ -1,0 +1,9 @@
+{
+  "root": "App",
+  "entry": "./",
+  "options": {
+    "child": "Home",
+    "port": "3000",
+    "title": "typescript_scss"
+  }
+}

--- a/src/command-line/print.ts
+++ b/src/command-line/print.ts
@@ -1,13 +1,13 @@
 import { colors } from "../lib/deps.ts";
 import { infoInterface } from "../lib/types.ts";
 
-const logo = (` 
-  __   ___ __   ___  
-  \\ \\ / / '_ \\ / _ \\ 
+const logo = (colors.bold(`
+  __   ___ __   ___
+  \\ \\ / / '_ \\ /   \\
    \\ V /| | | | (_) |
-    \\_/ |_| |_|\\___/         
+    \\_/ |_| |_|\\___/
+`));
 
-  `);
 // prints after build
 function ASCII() {
   console.log(colors.green(logo));
@@ -20,7 +20,9 @@ function QUIET() {
 function LISTEN(port: number, hostname?: string) {
   console.log(
     colors.green(
-      colors.italic(`dev server is listening on ${hostname}:${port}\n`),
+      colors.bold(
+        `dev server is listening on ${colors.blue(`http://localhost:${port}`)}\n`,
+      ),
     ),
   );
 }

--- a/src/command-line/templates.ts
+++ b/src/command-line/templates.ts
@@ -116,7 +116,6 @@ const htmlTemplate = (userOptions: terminalOptions) => {
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <script defer src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
     <link rel="stylesheet" href="./style.css" />
     <title>${userOptions.title}</title>
   </head>

--- a/src/command-line/templates.ts
+++ b/src/command-line/templates.ts
@@ -116,7 +116,7 @@ const htmlTemplate = (userOptions: terminalOptions) => {
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
     <link rel="stylesheet" href="./style.css" />
     <title>${userOptions.title}</title>
   </head>
@@ -124,7 +124,6 @@ const htmlTemplate = (userOptions: terminalOptions) => {
     <div id="${_.kebabCase(userOptions.root)}">
       <!-- built files will be auto injected -->
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
     <script type="module" src="./build.js"></script>
   </body>
 </html>

--- a/src/lib/deps.ts
+++ b/src/lib/deps.ts
@@ -26,3 +26,5 @@ export {
   scssCompiler,
   superoak,
 };
+
+export * from "https://deno.land/x/vue_sfc_compiler@v1.0.0/mod.ts";

--- a/src/lib/deps.ts
+++ b/src/lib/deps.ts
@@ -8,9 +8,21 @@ import * as asrt from "https://deno.land/std@0.83.0/testing/asserts.ts";
 // third-party
 import _ from "https://cdn.skypack.dev/lodash"; // lodash
 import ProgressBar from "https://deno.land/x/progress@v1.2.3/mod.ts";
+import { compile as scssCompiler } from "https://raw.githubusercontent.com/crewdevio/deno_sass2/master/mod.ts";
 
 // oak
 import * as oak from "https://deno.land/x/oak@v6.3.1/mod.ts";
 import { superoak } from "https://deno.land/x/superoak@3.0.0/mod.ts";
 
-export { _, colors, fs, http, oak, path, ProgressBar, superoak, asrt };
+export {
+  _,
+  asrt,
+  colors,
+  fs,
+  http,
+  oak,
+  path,
+  ProgressBar,
+  scssCompiler,
+  superoak,
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,6 +43,7 @@ export interface ComponentInterface {
   script?: string;
   style?: string;
   instance?: string;
+  middlecode?: string;
 }
 // #endregion
 
@@ -80,6 +81,7 @@ export interface UtilityInterface {
   preorderScrub: Function;
   multilineCommentPattern: string | RegExp;
   htmlCommentPattern: string | RegExp;
+  importPattern: RegExp;
 }
 // #endregion
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,6 +82,7 @@ export interface UtilityInterface {
   multilineCommentPattern: string | RegExp;
   htmlCommentPattern: string | RegExp;
   importPattern: RegExp;
+  urlPattern: RegExp;
 }
 // #endregion
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -126,7 +126,7 @@ export async function TsCompile(source: string, path: string, cut = true) {
     await Deno.remove(temp, { recursive: true });
     throw new Error(
       colors.red(
-        `Typescript compilation Error in ${colors.yellow(path)} => ${error}`,
+        `Typescript compilation Error in ${colors.yellow(path)}`,
       ),
     );
   }
@@ -147,7 +147,15 @@ export async function importResolver(
       // add component code to bundler detect resource call's
       await file.write(encoder.encode(`${source} ({ ${script} })`));
 
-      const [, output] = await Deno.bundle(temp, undefined, { strict: false });
+      const [diagnostic, output] = await Deno.bundle(temp, undefined, { strict: false });
+
+      // show bundler diagnostic
+      if (diagnostic?.length) {
+        diagnostic.forEach((file) => {
+          console.log(colors.yellow("[vno-warn]: "), colors.green(file.messageText ?? ""));
+        });
+      }
+
       // remove temp file
       await Deno.remove(temp, { recursive: true });
 
@@ -161,7 +169,7 @@ export async function importResolver(
     await Deno.remove(temp, { recursive: true });
     throw new Error(
       colors.red(
-        `Resolve bundler Error in ${colors.yellow(path)} => ${error}`,
+        `Resolve bundler Error in ${colors.yellow(path)}`,
       ),
     );
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -97,6 +97,7 @@ const utils: UtilityInterface = {
   multilineCommentPattern: /\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\//gm,
   htmlCommentPattern: /<!--([\s\S]*?)-->/gm,
   importPattern: /import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*$/gm,
+  urlPattern: /(ftp|http|https|file):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/gm
 };
 
 // compile typescript code to string javascrit code
@@ -152,7 +153,7 @@ export async function importResolver(
       // show bundler diagnostic
       if (diagnostic?.length) {
         diagnostic.forEach((file) => {
-          console.log(colors.yellow("[vno-warn]: "), colors.green(file.messageText ?? ""));
+          console.log(colors.yellow("[vno warn] => "), colors.green(file.messageText ?? ""));
         });
       }
 

--- a/src/strategies/compiler.ts
+++ b/src/strategies/compiler.ts
@@ -4,7 +4,7 @@ import { Storage } from "../lib/utils.ts";
 import _def from "../lib/defaults.ts";
 
 // #region Compiler
-// (3/3) in bundling cycle 
+// (3/3) in bundling cycle
 // Compiler writes component instances to build file
 // and writes styling to style css file
 // #endregion
@@ -13,7 +13,7 @@ function Compiler(this: CompilerInterface) {
   this.vue = `import Vue from '${Storage.root.vue}';\n`;
   // mounts the root component to the dom
   this.mount =
-    `\n${Storage.root.label}.$mount("#${Storage.root.name}");\nexport default ${Storage.root.label};\n`;
+    `\n${Storage.root.label}.$mount("#${Storage.root.name}");`;
 }
 
 // build establishes the build path and overwrites any previous builds

--- a/src/strategies/initialize.ts
+++ b/src/strategies/initialize.ts
@@ -31,7 +31,7 @@ Initialize.prototype.config = async function (options: OptionsInterface) {
     // the applications cdn is then saved on the root component object
     Storage.root.vue = options.vue || _def.CDN;
     // instantiate the Parser object and invoke the parse method
-    return new (Parser as any)().parse();
+    return await new (Parser as any)().parse();
   } catch (error) {
     return console.error(
       "Error inside of Initialize.config",

--- a/src/strategies/parser-utils/componentStringify.ts
+++ b/src/strategies/parser-utils/componentStringify.ts
@@ -7,15 +7,15 @@ import { ComponentInterface } from "../../lib/types.ts";
 // #endregion
 export default function componentStringify(current: ComponentInterface) {
   try {
-    const { label, name, template, script } = current;
+    const { label, name, template, script, middlecode } = current;
     // application root is written as a new Vue instance
     if (current.isRoot) {
       current.instance =
-        `\nconst ${label} = new Vue({template: \`${template}\`,${script}});\n`;
+        `\n${middlecode}\nconst ${label} = new Vue({template: \`${template}\`,${script}});\n`;
     } else {
       // all children components are registered to the instance
       current.instance =
-        `\nconst ${label} = Vue.component("${name}", {template: \`${template}\`,${script}});`;
+        `\n${middlecode}\nconst ${label} = Vue.component("${name}", {template: \`${template}\`,${script}});\n`;
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser-utils/componentStringify.ts
+++ b/src/strategies/parser-utils/componentStringify.ts
@@ -11,11 +11,11 @@ export default function componentStringify(current: ComponentInterface) {
     // application root is written as a new Vue instance
     if (current.isRoot) {
       current.instance =
-        `${middlecode}\nconst ${label} = new Vue({template: /*html*/\n\`${template}\`, ${script}});\n`;
+        `${middlecode ?? ""}\nconst ${label} = new Vue({template: /*html*/\n\`${template}\`, ${script}});\n`;
     } else {
       // all children components are registered to the instance
       current.instance =
-        `${middlecode}\nconst ${label} = Vue.component("${name}", {template: /*html*/\n\`${template}\`, ${script}});\n`;
+        `${middlecode ?? ""}\nconst ${label} = Vue.component("${name}", {template: /*html*/\n\`${template}\`, ${script}});\n`;
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser-utils/componentStringify.ts
+++ b/src/strategies/parser-utils/componentStringify.ts
@@ -11,11 +11,11 @@ export default function componentStringify(current: ComponentInterface) {
     // application root is written as a new Vue instance
     if (current.isRoot) {
       current.instance =
-        `\n${middlecode}\nconst ${label} = new Vue({template: \`${template}\`,${script}});\n`;
+        `${middlecode}\nconst ${label} = new Vue({template: \`${template}\`, ${script}});\n`;
     } else {
       // all children components are registered to the instance
       current.instance =
-        `\n${middlecode}\nconst ${label} = Vue.component("${name}", {template: \`${template}\`,${script}});\n`;
+        `${middlecode}\nconst ${label} = Vue.component("${name}", {template: \`${template}\`, ${script}});\n`;
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser-utils/componentStringify.ts
+++ b/src/strategies/parser-utils/componentStringify.ts
@@ -11,11 +11,11 @@ export default function componentStringify(current: ComponentInterface) {
     // application root is written as a new Vue instance
     if (current.isRoot) {
       current.instance =
-        `${middlecode}\nconst ${label} = new Vue({template: \`${template}\`, ${script}});\n`;
+        `${middlecode}\nconst ${label} = new Vue({template: /*html*/\n\`${template}\`, ${script}});\n`;
     } else {
       // all children components are registered to the instance
       current.instance =
-        `${middlecode}\nconst ${label} = Vue.component("${name}", {template: \`${template}\`, ${script}});\n`;
+        `${middlecode}\nconst ${label} = Vue.component("${name}", {template: /*html*/\n\`${template}\`, ${script}});\n`;
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser-utils/parseScript.ts
+++ b/src/strategies/parser-utils/parseScript.ts
@@ -1,5 +1,5 @@
+import Utils, { Queue, Storage, TsCompile, middleCodeResolver } from "../../lib/utils.ts";
 import { ComponentInterface } from "../../lib/types.ts";
-import Utils, { Queue, Storage, TsCompile } from "../../lib/utils.ts";
 import { _ } from "../../lib/deps.ts";
 
 import SiblingList from "../sibling.ts";
@@ -51,6 +51,8 @@ export default async function parseScript(current: ComponentInterface) {
         }
       }
 
+      // load all middle code inside a component
+      current.middlecode = await middleCodeResolver(current);
       // transform typescript to javascript
       if (useTypescript) {
         const source = await TsCompile(`({ ${current.script} })`, current.path as string) as string;

--- a/src/strategies/parser-utils/parseScript.ts
+++ b/src/strategies/parser-utils/parseScript.ts
@@ -5,9 +5,8 @@ import { _ } from "../../lib/deps.ts";
 import SiblingList from "../sibling.ts";
 
 // parseScript is responsible for parsing the data inside a files <script> tag
-export default async function parseScript(current: ComponentInterface) {
+export default async function parseScript(current: ComponentInterface, analysis: any) {
   try {
-    let useTypescript = false;
     if (current.split) {
       const { split } = current;
 
@@ -24,7 +23,7 @@ export default async function parseScript(current: ComponentInterface) {
         );
       }
 
-      const script = split.slice(open + 1, close).map((line) => {
+      const script = /* a.content; */ split.slice(open + 1, close).map((line) => {
         const comment = line.indexOf("//");
         if (comment > 0) return line.slice(0, comment);
         return line;
@@ -45,16 +44,10 @@ export default async function parseScript(current: ComponentInterface) {
       // returns a stringified and trimmed version of our components script
       current.script = Utils.sliceAndTrim(script, exportStart + 1, exportEnd);
 
-      for (const chunk of split) {
-        if (chunk.includes('lang="ts"')) {
-          useTypescript = true;
-        }
-      }
-
       // load all middle code inside a component
       current.middlecode = await middleCodeResolver(current);
       // transform typescript to javascript
-      if (useTypescript) {
+      if (analysis.lang === "ts") {
         const source = await TsCompile(`({ ${current.script} })`, current.path as string) as string;
         current.script =  source;
       }
@@ -72,7 +65,7 @@ export default async function parseScript(current: ComponentInterface) {
 
       // if a component's property is identified
       if (children) {
-        const componentsEnd = children.findIndex((el) => el.includes("}")) + 1;
+        const componentsEnd = children.findIndex((el: any) => el.includes("}")) + 1;
         // componentsStr is stringified and trimmed components property
         const componentsStr = Utils.sliceAndTrim(children, 0, componentsEnd);
 

--- a/src/strategies/parser-utils/parseStyle.ts
+++ b/src/strategies/parser-utils/parseStyle.ts
@@ -1,9 +1,11 @@
 import { ComponentInterface } from "../../lib/types.ts";
+import { scssCompiler } from "../../lib/deps.ts";
 import Utils from "../../lib/utils.ts";
 
 // parseStyle is responsible for parsing data inside of <style> tags
 export default function parseStyle(current: ComponentInterface) {
   try {
+    let useScss = false;
     if (current.split) {
       // isolate the content inside <style>
       const open = Utils.indexOfRegExp(/<style.*>/gi, current.split);
@@ -11,11 +13,26 @@ export default function parseStyle(current: ComponentInterface) {
       // return if the component has no added styling
       if (open < 0 || close < 0) {
         current.style = undefined;
-        return "parseStyle()=> succesful (no component styling)";
+        return "parseStyle()=> successful (no component styling)";
       }
       // stringify, trim, and save style to component object
       current.style = Utils.sliceAndTrim(current.split, open + 1, close);
       current.style = current.style.replace(Utils.multilineCommentPattern, "");
+
+      // detect scss style lang
+      for (const chunk of current.split) {
+        if (chunk.includes('lang="scss"')) {
+          useScss = true;
+        }
+      }
+
+      // stringify, trim, and save style to component object
+      current.style = Utils.sliceAndTrim(current.split, open + 1, close);
+
+      // compile scss to css
+      if (useScss) {
+        current.style = scssCompiler(current.style as string);
+      }
     }
   } catch (error) {
     console.error(

--- a/src/strategies/parser-utils/parseStyle.ts
+++ b/src/strategies/parser-utils/parseStyle.ts
@@ -3,9 +3,9 @@ import { scssCompiler } from "../../lib/deps.ts";
 import Utils from "../../lib/utils.ts";
 
 // parseStyle is responsible for parsing data inside of <style> tags
-export default function parseStyle(current: ComponentInterface) {
+export default function parseStyle(current: ComponentInterface, styles: any) {
   try {
-    let useScss = false;
+    // current.split = current.split?.map((text) => text.replace("\r", ""));
     if (current.split) {
       // isolate the content inside <style>
       const open = Utils.indexOfRegExp(/<style.*>/gi, current.split);
@@ -16,21 +16,12 @@ export default function parseStyle(current: ComponentInterface) {
         return "parseStyle()=> successful (no component styling)";
       }
       // stringify, trim, and save style to component object
-      current.style = Utils.sliceAndTrim(current.split, open + 1, close);
-      current.style = current.style.replace(Utils.multilineCommentPattern, "");
+      current.style = styles[0].content.replace(
+        Utils.multilineCommentPattern,
+        "",
+      );
 
-      // detect scss style lang
-      for (const chunk of current.split) {
-        if (chunk.includes('lang="scss"')) {
-          useScss = true;
-        }
-      }
-
-      // stringify, trim, and save style to component object
-      current.style = Utils.sliceAndTrim(current.split, open + 1, close);
-
-      // compile scss to css
-      if (useScss) {
+      if (styles[0].lang === "scss") {
         current.style = scssCompiler(current.style as string);
       }
     }

--- a/src/strategies/parser-utils/parseTemplate.ts
+++ b/src/strategies/parser-utils/parseTemplate.ts
@@ -4,6 +4,8 @@ import Utils from "../../lib/utils.ts";
 // parseTemplate is responsible for parsing template tags
 export default function parseTemplate(current: ComponentInterface) {
   try {
+    // remove '\r' to prevent isolation error
+    current.split = current.split?.map((piece: string) => piece.replace("\r", ""));
     if (current.split) {
       const { split } = current;
       // isolate the content inside <template>

--- a/src/strategies/parser-utils/parseTemplate.ts
+++ b/src/strategies/parser-utils/parseTemplate.ts
@@ -3,7 +3,7 @@ import Utils from "../../lib/utils.ts";
 import { compileTemplate } from "../../lib/deps.ts";
 
 // parseTemplate is responsible for parsing template tags
-export default function parseTemplate(ast: any, current: ComponentInterface) {
+export default function parseTemplate(current: ComponentInterface, ast: any) {
   try {
     current.split = current.split?.map((text) => text.replace("\r", ""));
 

--- a/src/strategies/parser.ts
+++ b/src/strategies/parser.ts
@@ -2,6 +2,7 @@ import Compiler from "./compiler.ts";
 
 import { ParserInterface } from "../lib/types.ts";
 import { Queue, Storage } from "../lib/utils.ts";
+import { colors, parse } from "../lib/deps.ts";
 
 import fn from "./parser-utils/_fn.ts";
 
@@ -18,11 +19,24 @@ Parser.prototype.parse = async function () {
   // iterate through the Queue while it is populated
   while (Queue.length) {
     const current = Queue.shift();
+    // normalize source
+    const sourceRaw = current?.split
+      ?.join("");
+
+    const astSource =
+      parse(sourceRaw, { filename: `${current?.label}.vue`, sourceMap: false })
+        .descriptor;
 
     if (current) {
-      fn.parseTemplate(current);
-      await fn.parseScript(current);
-      fn.parseStyle(current);
+      console.log(
+        colors.green(
+          `[vno: compiling] => ${colors.yellow(current.path as string)}`,
+        ),
+      );
+
+      fn.parseTemplate(astSource.template, current);
+      await fn.parseScript(current, astSource.script);
+      fn.parseStyle(current, astSource.styles);
       fn.componentStringify(current);
       current.isParsed = true;
     }

--- a/src/strategies/parser.ts
+++ b/src/strategies/parser.ts
@@ -23,9 +23,10 @@ Parser.prototype.parse = async function () {
     const sourceRaw = current?.split
       ?.join("");
 
-    const astSource =
-      parse(sourceRaw, { filename: `${current?.label}.vue`, sourceMap: false })
-        .descriptor;
+    const astSource = parse(
+      sourceRaw,
+      { filename: `${current?.label}.vue`, sourceMap: false },
+    );
 
     if (current) {
       console.log(
@@ -34,11 +35,21 @@ Parser.prototype.parse = async function () {
         ),
       );
 
-      fn.parseTemplate(astSource.template, current);
-      await fn.parseScript(current, astSource.script);
-      fn.parseStyle(current, astSource.styles);
-      fn.componentStringify(current);
-      current.isParsed = true;
+      // show static analysis errors
+      if (astSource.errors.length) {
+        console.log(colors.red("\nstatic analysis Error:"));
+        astSource.errors.forEach((error: string) => {
+          console.error(error);
+        });
+      }
+
+      else {
+        fn.parseTemplate(current, astSource.descriptor.template);
+        await fn.parseScript(current, astSource.descriptor.script);
+        fn.parseStyle(current, astSource.descriptor.styles);
+        fn.componentStringify(current);
+        current.isParsed = true;
+      }
     }
   }
   // return a new instance of Compiler and run the build method

--- a/src/strategies/parser.ts
+++ b/src/strategies/parser.ts
@@ -14,14 +14,14 @@ function Parser(this: ParserInterface) {
 
 // parse is responsible for invoking all the parser-utils
 // functions for each component in the Queue.
-Parser.prototype.parse = function () {
+Parser.prototype.parse = async function () {
   // iterate through the Queue while it is populated
   while (Queue.length) {
     const current = Queue.shift();
 
     if (current) {
       fn.parseTemplate(current);
-      fn.parseScript(current);
+      await fn.parseScript(current);
       fn.parseStyle(current);
       fn.componentStringify(current);
       current.isParsed = true;


### PR DESCRIPTION
to use typescript or scss you just need to add these attributes

for typescript

```html
<script lang="ts">
```

for scss

```html
<style lang="scss">
```

for the compiler to resolve the external imports and the intermediate code just add the load attribute

```html
<script lang="ts" load>
import Home from "./components/Home.vue";
import { Name } from "./Name.ts";

console.log("Hello vno");

export default {
  name: "app",
  components: { Home },
  data(): { message: string, name: string } {
    const message: string = "you are building: Vue App with vno";

    return {
      message,
      name: Name
    };
  },
};
</script>
```
imports and intermediate code are injected just above the component declaration, if something is imported and it is not used within the declaration of the vue component or in the intermediate section it will not be grouped in the final compile.