### PR TITLE
upgrade opine

### DIFF
--- a/core/cli/ssr.ts
+++ b/core/cli/ssr.ts
@@ -1,5 +1,5 @@
 
-import { opine, serveStatic } from "https://deno.land/x/opine@1.2.0/mod.ts";
+import { opine, serveStatic } from "https://deno.land/x/opine@1.3.3/mod.ts";
 import  vueServerRenderer  from 'https://deno.land/x/vue_server_renderer@/mod.js';
 import App from '../../vendor/component.js';
 import { join, dirname} from "https://deno.land/std@0.63.0/path/mod.ts";

--- a/core/cli/templates.ts
+++ b/core/cli/templates.ts
@@ -148,7 +148,7 @@ export const vnoConfig = (options: CreateInputs) => {
 };
 
 export const ssrTemplate =
-  `import { opine, serveStatic } from "https://deno.land/x/opine@1.2.0/mod.ts";
+  `import { opine, serveStatic } from "https://deno.land/x/opine@1.3.3/mod.ts";
 import  vueServerRenderer from 'https://deno.land/x/vue_server_renderer@/mod.js';
 
 import App from './vno-ssr/build.js';


### PR DESCRIPTION
Upgraded Opine to latest version (1.3.3) to prevent error resulting in browser stack trace.